### PR TITLE
feature: ragged.sort and ragged.argsort

### DIFF
--- a/src/ragged/_spec_sorting_functions.py
+++ b/src/ragged/_spec_sorting_functions.py
@@ -6,7 +6,9 @@ https://data-apis.org/array-api/latest/API_specification/sorting_functions.html
 
 from __future__ import annotations
 
-from ._spec_array_object import array
+import awkward as ak
+
+from ._spec_array_object import _box, _unbox, array
 
 
 def argsort(
@@ -34,11 +36,12 @@ def argsort(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.argsort.html
     """
 
-    x  # noqa: B018, pylint: disable=W0104
-    axis  # noqa: B018, pylint: disable=W0104
-    descending  # noqa: B018, pylint: disable=W0104
-    stable  # noqa: B018, pylint: disable=W0104
-    raise NotImplementedError("TODO 132")  # noqa: EM101
+    (impl,) = _unbox(x)
+    if not isinstance(impl, ak.Array):
+        msg = f"axis {axis} is out of bounds for array of dimension 0"
+        raise ak.errors.AxisError(msg)
+    out = ak.argsort(impl, axis=axis, ascending=not descending, stable=stable)
+    return _box(type(x), out)
 
 
 def sort(
@@ -66,8 +69,9 @@ def sort(
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.sort.html
     """
 
-    x  # noqa: B018, pylint: disable=W0104
-    axis  # noqa: B018, pylint: disable=W0104
-    descending  # noqa: B018, pylint: disable=W0104
-    stable  # noqa: B018, pylint: disable=W0104
-    raise NotImplementedError("TODO 133")  # noqa: EM101
+    (impl,) = _unbox(x)
+    if not isinstance(impl, ak.Array):
+        msg = f"axis {axis} is out of bounds for array of dimension 0"
+        raise ak.errors.AxisError(msg)
+    out = ak.sort(impl, axis=axis, ascending=not descending, stable=stable)
+    return _box(type(x), out)

--- a/tests/test_spec_sorting_functions.py
+++ b/tests/test_spec_sorting_functions.py
@@ -6,9 +6,90 @@ https://data-apis.org/array-api/latest/API_specification/sorting_functions.html
 
 from __future__ import annotations
 
+import pytest
+
 import ragged
+
+devices = ["cpu"]
+try:
+    import cupy as cp
+
+    # FIXME!
+    # devices.append("cuda")
+except ModuleNotFoundError:
+    cp = None
 
 
 def test_existence():
     assert ragged.argsort is not None
     assert ragged.sort is not None
+
+
+@pytest.mark.parametrize("device", devices)
+def test_argsort(device):
+    x = ragged.array(
+        [[1.1, 0, 2.2], [], [3.3, 4.4], [5.5], [9.9, 7.7, 8.8, 6.6]], device=device
+    )
+    assert ragged.argsort(x, axis=1, stable=True, descending=False).tolist() == [  # type: ignore[comparison-overlap]
+        [1, 0, 2],
+        [],
+        [0, 1],
+        [0],
+        [3, 1, 2, 0],
+    ]
+    assert ragged.argsort(x, axis=1, stable=True, descending=True).tolist() == [  # type: ignore[comparison-overlap]
+        [2, 0, 1],
+        [],
+        [1, 0],
+        [0],
+        [0, 2, 1, 3],
+    ]
+    assert ragged.argsort(x, axis=0, stable=True, descending=False).tolist() == [  # type: ignore[comparison-overlap]
+        [0, 0, 0],
+        [],
+        [2, 2],
+        [3],
+        [4, 4, 4, 4],
+    ]
+    assert ragged.argsort(x, axis=0, stable=True, descending=True).tolist() == [  # type: ignore[comparison-overlap]
+        [4, 4, 4],
+        [],
+        [3, 2],
+        [2],
+        [0, 0, 0, 4],
+    ]
+
+
+@pytest.mark.parametrize("device", devices)
+def test_sort(device):
+    x = ragged.array(
+        [[1.1, 0, 2.2], [], [3.3, 4.4], [5.5], [9.9, 7.7, 8.8, 6.6]], device=device
+    )
+    assert ragged.sort(x, axis=1, stable=True, descending=False).tolist() == [  # type: ignore[comparison-overlap]
+        [0, 1.1, 2.2],
+        [],
+        [3.3, 4.4],
+        [5.5],
+        [6.6, 7.7, 8.8, 9.9],
+    ]
+    assert ragged.sort(x, axis=1, stable=True, descending=True).tolist() == [  # type: ignore[comparison-overlap]
+        [2.2, 1.1, 0],
+        [],
+        [4.4, 3.3],
+        [5.5],
+        [9.9, 8.8, 7.7, 6.6],
+    ]
+    assert ragged.sort(x, axis=0, stable=True, descending=False).tolist() == [  # type: ignore[comparison-overlap]
+        [1.1, 0.0, 2.2],
+        [],
+        [3.3, 4.4],
+        [5.5],
+        [9.9, 7.7, 8.8, 6.6],
+    ]
+    assert ragged.sort(x, axis=0, stable=True, descending=True).tolist() == [  # type: ignore[comparison-overlap]
+        [9.9, 7.7, 8.8],
+        [],
+        [5.5, 4.4],
+        [3.3],
+        [1.1, 0.0, 2.2, 6.6],
+    ]


### PR DESCRIPTION
I thought, "The ragged library is very formulaic. If the the Glorified Autocomplete is good at anything, it would be filling in these `NotImplementedError("TODO")` stubs, right?"

Well... even with a context window full of the already-implemented functions, it wrote

```python
    (impl,) = _unbox(x)
    kind = 'stable' if stable else 'quicksort'
    order = 'F' if descending else 'C'
    if isinstance(impl, ak.Array):
        sorted_indices = ak.argsort(impl, axis=axis, ascending=not descending, stable=stable)
    else:
        sorted_indices = np.argsort(impl, axis=axis, kind=kind, order=order)
    return _box(type(x), sorted_indices)
```

for `argsort` and

```python
    (impl,) = _unbox(x)
    if isinstance(impl, ak.Array):
        sorted_array = ak.sort(impl, axis=axis, ascending=not descending, stable=stable)
    else:
        # NumPy does not directly support stable sorting in descending order, so we need to handle it ourselves
        if descending:
            sorted_array = np.sort(impl, axis=axis, kind='stable' if stable else 'quicksort')[::-1]
        else:
            sorted_array = np.sort(impl, axis=axis, kind='stable' if stable else 'quicksort')
    return _box(type(x), sorted_array)
```

for `sort`.

What's with the Fortran (`'F'`) and C-contiguous (`'C'`) ordering? That's for memory layout, and none of the other functions have that. The confusion between "order" and "sorting" makes sense in the context of natural language, but they don't have anything to do with each other here. (Actually, NumPy sorting functions have an `order`, which refers to fields in a structured array—not memory-contiguousness!)

I probably should have given it Awkward's `argsort` and `sort` docstrings, but these are not Awkward's arguments.

Maybe it was natural to branch and do both Awkward and NumPy implementations, but in ragged, the alternative of an Awkward Array is a NumPy or CuPy _scalar_, which doesn't make sense to sort.

Finally, it's true that NumPy doesn't have a `descending` flag. (ChatGPT must have known that from its training dataset. It's the sort of thing people would warn each other about on StackOverflow.) But it only seemed to know that on the second of two functions.

Okay: coding (in the most formulaic instance I can find) is a bust. What about writing tests?

```python
@pytest.mark.parametrize("device", devices)
@pytest.mark.parametrize("data, expected_indices", [
    ([3, 1, 2], [1, 2, 0]),
    ([[1, 0], [3, 2]], [[1, 0], [1, 0]]),
    ([[5, 7], [], [3, 1]], [[1, 0], [], [1, 0]]),
])
def test_argsort(device, data, expected_indices):
    x = ragged.array(data, device=device)
    result = ragged.argsort(x)
    assert result.tolist() == expected_indices, "Argsort indices mismatch."


@pytest.mark.parametrize("device", devices)
@pytest.mark.parametrize("data, expected_sorted", [
    ([3, 1, 2], [1, 2, 3]),
    ([[3, 2], [1, 0]], [[2, 3], [0, 1]]),
    ([[5, 7], [], [3, 1]], [[5, 7], [], [1, 3]]),
])
def test_sort(device, data, expected_sorted):
    x = ragged.array(data, device=device)
    result = ragged.sort(x)
    assert result.tolist() == expected_sorted, "Sort order mismatch."


@pytest.mark.parametrize("device", devices)
@pytest.mark.parametrize("descending", [False, True])
@pytest.mark.parametrize("stable", [False, True])
def test_argsort_sort_options(device, descending, stable):
    data = [2, 3, 1, 4]
    expected_indices_desc = [3, 1, 0, 2] if descending else [2, 0, 1, 3]
    expected_sorted_desc = [4, 3, 2, 1] if descending else [1, 2, 3, 4]

    x = ragged.array(data, device=device)
    result_indices = ragged.argsort(x, descending=descending, stable=stable)
    result_sorted = ragged.sort(x, descending=descending, stable=stable)

    assert result_indices.tolist() == expected_indices_desc, f"Argsort descending={descending}, stable={stable} failed."
    assert result_sorted.tolist() == expected_sorted_desc, f"Sort descending={descending}, stable={stable} failed."
```

On the first two, the the `expected_sorted` has a different depth of nesting than the `data`, so it couldn't possibly be right. But maybe the problem is that the inputs and expected outputs are all written in a `parametrize` decorator—do people actually do that? I find that it helps to have inputs and expected outputs near each other, clearly lined up, and if they're separate arguments to the `parametrize` decorator, they can't be lined up.

Speaking of which,

```python
assert result.tolist() == expected_indices, "Argsort indices mismatch."
```

Really? You needed the explanation, instead of letting the assertion stand on its own? I suspect that this sort of thing comes from bad practices in the wild:

```python
# In this comment, I will tell you what is happening in the next line. It is a comment.
# This is the comment I referred to on the previous line. In this comment, I will tell
# you about the code on the next line. It is a print statement. It prints, "hello world".
print("hello world")
# The previous line printed "hello world" to the screen, terminal, Jupyter notebook, or
# other output device where printed lines are printed.
```

The third test looks right, but why not test the options in all tests? And how about different `axis` values? (I gave ChatGPT the statically typed, docstringed implementation of the functions it was supposed to test.)

All in all, it's a bust. But it's funny to be complaining about LLMs not being able to write code for me when I was so blown away by them being able to produce anything meaningful just 10 years ago, in [The Unreasonable Effectiveness of Recurrent Neural Networks](https://karpathy.github.io/2015/05/21/rnn-effectiveness/). I suppose I'm spoiled.