### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,20 +64,22 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
       - name: Install old NumPy
         if: matrix.numpy-version != 'latest'
-        run: python -m pip install numpy==${{ matrix.numpy-version }}
+        run: uv pip install --system numpy==${{ matrix.numpy-version }}
 
       - name: Install package
-        run: python -m pip install .[test]
+        run: uv pip install --system '.[test]'
 
       - name: Print NumPy version
         run: python -c 'import numpy as np; print(np.__version__)'
 
       - name: Test package
         run: >-
-          python -m pytest -ra --cov --cov-report=xml --cov-report=term
-          --durations=20
+          pytest -ra --cov --cov-report=xml --cov-report=term --durations=20
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4.3.0


### PR DESCRIPTION
* Use 'uv pip' for all calls to 'pip install' in CI workflows.
   - c.f. https://github.com/astral-sh/uv/
* Use 'pytest' over 'python -m pytest' as calling pytest as a main module also includes the current directory on the path.