### PR TITLE
build: Add lower bound on awkward of v2.5.0

### DIFF
--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -1,9 +1,10 @@
 name: Minimum supported dependencies
 
 on:
-  # Run weekly at 1:23 UTC
-  schedule:
-    - cron: "23 1 * * 0"
+  pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -1,0 +1,36 @@
+name: Minimum supported dependencies
+
+on:
+  # Run weekly at 1:23 UTC
+  schedule:
+    - cron: "23 1 * * 0"
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # minimum supported Python
+        python-version: ["3.9"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies and force lowest bound
+        run: |
+          python -m pip install uv
+          uv pip install --system --upgrade ".[test]"
+          uv pip install --system --upgrade --resolution lowest-direct .
+
+      - name: List installed Python packages
+        run: uv pip list --system
+
+      - name: Test with pytest
+        run: pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "awkward",
+  "awkward>=2.5.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The lower bound is empirically determined with

```
uv pip install --upgrade --resolution lowest-direct . && pytest tests/
```

as v2.5.0 requires awkward-cpp v26+ which is required for attrs to be accessed.

Also add scheduled CI to test these lower bounds.