### PR TITLE
use ak.prettyprint instead of ak._prettyprint

### DIFF
--- a/src/ragged/_spec_array_object.py
+++ b/src/ragged/_spec_array_object.py
@@ -244,9 +244,9 @@ class array:  # pylint: disable=C0103
         if len(self._shape) == 0:
             return f"{self._impl}"
         elif len(self._shape) == 1:
-            return f"{ak._prettyprint.valuestr(self._impl, 1, 80)}"
+            return f"{ak.prettyprint.valuestr(self._impl, 1, 80)}"
         else:
-            prep = ak._prettyprint.valuestr(self._impl, 20, 80 - 4)[1:-1].replace(
+            prep = ak.prettyprint.valuestr(self._impl, 20, 80 - 4)[1:-1].replace(
                 "\n ", "\n    "
             )
             return f"[\n    {prep}\n]"
@@ -259,9 +259,9 @@ class array:  # pylint: disable=C0103
         if len(self._shape) == 0:
             return f"ragged.array({self._impl})"
         elif len(self._shape) == 1:
-            return f"ragged.array({ak._prettyprint.valuestr(self._impl, 1, 80 - 14)})"
+            return f"ragged.array({ak.prettyprint.valuestr(self._impl, 1, 80 - 14)})"
         else:
-            prep = ak._prettyprint.valuestr(self._impl, 20, 80 - 4)[1:-1].replace(
+            prep = ak.prettyprint.valuestr(self._impl, 20, 80 - 4)[1:-1].replace(
                 "\n ", "\n    "
             )
             return f"ragged.array([\n    {prep}\n])"


### PR DESCRIPTION
Otherwise i keep getting:

AttributeError: module 'awkward' has no attribute '_prettyprint'


```python
22:40 $ ipython
^[[APython 3.10.14 | packaged by Ramona Optics | (main, Aug  5 2024, 02:52:33) [GCC 12.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.26.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: >>> import ragged
   ...: >>> array = ragged.array([[[1.1, 2.2, 3.3], [], [4.4, 5.5]], [], [[6.6], [7.7, 8.8, 9.9
   ...: ]]])
   ...: >>> array
   ...: ragged.array([
   ...:     [[1.1, 2.2, 3.3], [], [4.4, 5.5]],
   ...:     [],
   ...:     [[6.6], [7.7, 8.8, 9.9]]
   ...: ])
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/miniforge3/envs/dev/lib/python3.10/site-packages/IPython/core/formatters.py:711, in PlainTextFormatter.__call__(self, obj)
    704 stream = StringIO()
    705 printer = pretty.RepresentationPrinter(stream, self.verbose,
    706     self.max_width, self.newline,
    707     max_seq_length=self.max_seq_length,
    708     singleton_pprinters=self.singleton_printers,
    709     type_pprinters=self.type_printers,
    710     deferred_pprinters=self.deferred_printers)
--> 711 printer.pretty(obj)
    712 printer.flush()
    713 return stream.getvalue()

File ~/miniforge3/envs/dev/lib/python3.10/site-packages/IPython/lib/pretty.py:419, in RepresentationPrinter.pretty(self, obj)
    408                         return meth(obj, self, cycle)
    409                 if (
    410                     cls is not object
    411                     # check if cls defines __repr__
   (...)
    417                     and callable(_safe_getattr(cls, "__repr__", None))
    418                 ):
--> 419                     return _repr_pprint(obj, self, cycle)
    421     return _default_pprint(obj, self, cycle)
    422 finally:

File ~/miniforge3/envs/dev/lib/python3.10/site-packages/IPython/lib/pretty.py:787, in _repr_pprint(obj, p, cycle)
    785 """A pprint that just redirects to the normal repr function."""
    786 # Find newlines and replace them with p.break_()
--> 787 output = repr(obj)
    788 lines = output.splitlines()
    789 with p.group():

File ~/miniforge3/envs/dev/lib/python3.10/site-packages/ragged/_spec_array_object.py:264, in array.__repr__(self)
    262     return f"ragged.array({ak._prettyprint.valuestr(self._impl, 1, 80 - 14)})"
    263 else:
--> 264     prep = ak._prettyprint.valuestr(self._impl, 20, 80 - 4)[1:-1].replace(
    265         "\n ", "\n    "
    266     )
    267     return f"ragged.array([\n    {prep}\n])"

AttributeError: module 'awkward' has no attribute '_prettyprint'
```


```
$ mamba list | grep -E "(ragged|awkward)"
awkward                   2.6.7              pyhd8ed1ab_0    conda-forge
awkward-cpp               37              py310haa687a3_0    conda-forge
ragged                    0.1.0              pyh267e887_0    mark.harfouche
```