### PR TITLE
fix: an unexpected 'equal_nan' keyword argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             numpy-version: "latest"
             runs-on: ubuntu-latest
           - python-version: "3.9"
-            numpy-version: "1.22.0"
+            numpy-version: "1.24.0"
             runs-on: ubuntu-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "awkward>=2.6.7",
+  "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes TypeError: _unique_dispatcher() got an unexpected keyword argument 'equal_nan'

'equal_nan' was introduced from Numpy 1.24
https://numpy.org/doc/1.24/reference/generated/numpy.unique.html