### PR TITLE
feat(indexing): implement take_along_axis for Array API compliance

### DIFF
--- a/src/ragged/__init__.py
+++ b/src/ragged/__init__.py
@@ -113,6 +113,7 @@ from ._spec_elementwise_functions import (  # pylint: disable=W0622
 )
 from ._spec_indexing_functions import (
     take,
+    take_along_axis,
 )
 from ._spec_linear_algebra_functions import (
     matmul,
@@ -263,6 +264,7 @@ __all__ = [
     "trunc",
     # _spec_indexing_functions
     "take",
+    "take_along_axis",
     # _spec_linear_algebra_functions
     "matmul",
     "matrix_transpose",

--- a/src/ragged/_spec_indexing_functions.py
+++ b/src/ragged/_spec_indexing_functions.py
@@ -6,10 +6,13 @@ https://data-apis.org/array-api/latest/API_specification/indexing_functions.html
 
 from __future__ import annotations
 
+import contextlib
+from typing import Any
+
 import awkward as ak
 import numpy as np
 
-from ._spec_array_object import _box, array
+from ._spec_array_object import _box, _unbox, array
 
 
 def take(x: array, indices: array, /, *, axis: None | int = None) -> array:
@@ -64,3 +67,63 @@ def take(x: array, indices: array, /, *, axis: None | int = None) -> array:
 
     slicer = (slice(None),) * axis + (indexarray,)
     return _box(type(x), toslice[slicer])
+
+
+def take_along_axis(x: array, indices: array, /, *, axis: int = -1) -> array:
+    """
+    Selects elements from an array using indices along a given axis.
+
+    Args:
+        x: Input array.
+        indices: Array indices. Must have the same rank as ``x``.
+        axis: Axis over which to select values. If negative, counts from the last dimension.
+            Default: ``-1``.
+
+    Returns:
+        An array having the same data type as ``x`` and the same shape as ``indices``.
+
+    https://data-apis.org/array-api/latest/API_specification/generated/array_api.take_along_axis.html
+    """
+    x_impl, indices_impl = _unbox(x, indices)
+
+    if x.ndim != indices.ndim:
+        msg = f"indices and x must have the same rank, got {indices.ndim} and {x.ndim}"
+        raise ValueError(msg)
+
+    # Normalize negative axis
+    original_axis = axis
+    if axis < 0:
+        axis += x.ndim
+    if not 0 <= axis < x.ndim:
+        msg = f"axis {original_axis} is out of bounds for array of dimension {x.ndim}"
+        raise ValueError(msg)
+
+    # Fast path: uniform arrays via numpy
+    with contextlib.suppress(TypeError, ValueError):
+        x_np = ak.to_numpy(x_impl)
+        indices_np = ak.to_numpy(indices_impl)
+        result_np = np.take_along_axis(x_np, indices_np, axis=axis)
+        return _box(type(x), ak.from_numpy(result_np))
+
+    # Ragged path via Awkward Array
+    if axis == x.ndim - 1:
+        # For the innermost axis, awkward array natively supports gathering
+        # via direct indexing: x_impl[indices_impl]
+        return _box(type(x), x_impl[indices_impl])  # type: ignore[index]
+
+    # For outer axes in ragged arrays, we fall back to list reconstruction.
+    # (Since outer-axis gathering across ragged boundaries is complex and rare).
+    def _take_along(arr_obj: Any, idx_obj: Any, current_depth: int) -> Any:
+        if current_depth == axis:
+            return [arr_obj[i] for i in idx_obj]
+
+        # Zip elements together and recurse
+        return [
+            _take_along(a_item, i_item, current_depth + 1)
+            for a_item, i_item in zip(arr_obj, idx_obj, strict=False)
+        ]
+
+    x_list = ak.to_list(x_impl)
+    indices_list = ak.to_list(indices_impl)
+
+    return _box(type(x), ak.Array(_take_along(x_list, indices_list, 0)))

--- a/tests/test_spec_indexing_functions.py
+++ b/tests/test_spec_indexing_functions.py
@@ -6,8 +6,51 @@ https://data-apis.org/array-api/latest/API_specification/indexing_functions.html
 
 from __future__ import annotations
 
+import awkward as ak
+import numpy as np
+import pytest
+
 import ragged
+
+
+def _make(data, dtype=None) -> ragged.array:
+    return ragged.array(data, dtype=dtype)
 
 
 def test_existence():
     assert ragged.take is not None
+    assert ragged.take_along_axis is not None
+
+
+class TestTakeAlongAxis:
+    def test_1d_uniform(self):
+        a = _make([10, 20, 30, 40], dtype=np.int64)
+        indices = _make([2, 0, 3], dtype=np.int64)
+        result = ragged.take_along_axis(a, indices, axis=0)
+        assert ak.to_list(result) == [30, 10, 40]
+        assert result.dtype == np.int64
+
+    def test_2d_uniform_numpy_fast_path(self):
+        a = _make([[10, 20, 30], [40, 50, 60]])
+        indices = _make([[0, 2], [1, 1]], dtype=np.int64)
+        result = ragged.take_along_axis(a, indices, axis=1)
+        assert ak.to_list(result) == [[10, 30], [50, 50]]
+
+    def test_2d_ragged_innermost_axis(self):
+        # Ragged array innermost dimension gather
+        a = _make([[10, 20, 30], [40, 50]])
+        indices = _make([[2, 0], [1]], dtype=np.int64)
+        result = ragged.take_along_axis(a, indices, axis=1)
+        assert ak.to_list(result) == [[30, 10], [50]]
+
+    def test_error_rank_mismatch(self):
+        a = _make([[10, 20], [30, 40]])
+        indices = _make([0, 1], dtype=np.int64)
+        with pytest.raises(ValueError, match="same rank"):
+            ragged.take_along_axis(a, indices, axis=0)
+
+    def test_error_axis_out_of_bounds(self):
+        a = _make([10, 20])
+        indices = _make([0])
+        with pytest.raises(ValueError, match="out of bounds"):
+            ragged.take_along_axis(a, indices, axis=1)


### PR DESCRIPTION
### Description
This PR implements `take_along_axis` for full Array API compliance, resolving the outstanding task tracked in #136.

### Implementation Details
- **Signatures & Imports:** Handled dynamic typing imports and exposed the function in `__init__.py`.
- **Fast Path:** Added optimal NumPy-based execution (`np.take_along_axis`) for uniform array structures inside a single try/except block.
- **Ragged Path:** Vectorized the innermost axis (`axis=-1`) gathering via direct Awkward array slicing (`x_impl[indices_impl]`). Added recursive list-based processing for outer-axis gathering on non-uniform structures.
- **QA & Verification:** Ruff formatting/linting and strict Mypy checks are 100% clean. All 1,308 unit tests pass
@ianna let me know your thouhgts on this and for any suggestions. 