### PR TITLE
fix: dtype handling and axis validation in statistical functions

### DIFF
--- a/src/ragged/_spec_statistical_functions.py
+++ b/src/ragged/_spec_statistical_functions.py
@@ -30,8 +30,9 @@ def _regularize_axis(
         out = []
         for x in axis:  # type: ignore[union-attr]
             out.append(x + ndim if x < 0 else x)
-            if not 0 < out[-1] < ndim:
+            if not 0 <= out[-1] < ndim:
                 msg = f"axis {x} is out of bounds for an array with {ndim} dimensions"
+                raise ak.errors.AxisError(msg)
         if len(out) == 0:
             msg = "at least one axis must be specified"
             raise ak.errors.AxisError(msg)
@@ -132,7 +133,9 @@ def mean(
         If the arithmetic mean was computed over the entire array, a
         zero-dimensional array containing the arithmetic mean; otherwise, a
         non-zero-dimensional array containing the arithmetic means. The
-        returned array has the same data type as `x`.
+        returned array has a floating-point data type: the same data type as
+        `x` if `x` is floating-point, otherwise the default floating-point data
+        type.
 
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.mean.html
     """
@@ -150,7 +153,10 @@ def mean(
         sumw = ak.count(*_unbox(x), axis=axis, keepdims=keepdims)
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        return _ensure_dtype(_box(type(x), sumwx / sumw), x.dtype)
+        out = _box(type(x), sumwx / sumw)
+        if x.dtype.kind in "fc":
+            out = _ensure_dtype(out, x.dtype)
+        return out
 
 
 def min(  # pylint: disable=W0622
@@ -252,7 +258,7 @@ def prod(
 
     axis = _regularize_axis(axis, x.ndim)
     dtype = _regularize_dtype(dtype, x.dtype)
-    arr = _box(type(x), ak.values_astype(*_unbox(x), dtype)) if x.dtype == dtype else x
+    arr = _ensure_dtype(x, dtype)
 
     if isinstance(axis, tuple):
         (out,) = _unbox(arr)
@@ -302,7 +308,9 @@ def std(
         If the standard deviation was computed over the entire array, a
         zero-dimensional array containing the standard deviation; otherwise, a
         non-zero-dimensional array containing the standard deviations.
-        The returned array has the same data type as `x`.
+        The returned array has a floating-point data type: the same data type
+        as `x` if `x` is floating-point, otherwise the default floating-point
+        data type.
 
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.std.html
     """
@@ -366,7 +374,7 @@ def sum(  # pylint: disable=W0622
 
     axis = _regularize_axis(axis, x.ndim)
     dtype = _regularize_dtype(dtype, x.dtype)
-    arr = _box(type(x), ak.values_astype(*_unbox(x), dtype)) if x.dtype == dtype else x
+    arr = _ensure_dtype(x, dtype)
 
     if isinstance(axis, tuple):
         (out,) = _unbox(arr)
@@ -413,8 +421,9 @@ def var(
     Returns:
         If the variance was computed over the entire array, a zero-dimensional
         array containing the variance; otherwise, a non-zero-dimensional array
-        containing the variances. The returned array has the same data type as
-        `x`.
+        containing the variances. The returned array has a floating-point data
+        type: the same data type as `x` if `x` is floating-point, otherwise the
+        default floating-point data type.
 
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.var.html
     """
@@ -438,4 +447,7 @@ def var(
         out = sumwxx / sumw - np.square(sumwx / sumw)
         if correction is not None and correction != 0:
             out *= sumw / (sumw - correction)
-        return _ensure_dtype(_box(type(x), out), x.dtype)
+        result = _box(type(x), out)
+        if x.dtype.kind in "fc":
+            result = _ensure_dtype(result, x.dtype)
+        return result

--- a/tests/test_spec_statistical_functions.py
+++ b/tests/test_spec_statistical_functions.py
@@ -6,6 +6,8 @@ https://data-apis.org/array-api/latest/API_specification/statistical_functions.h
 
 from __future__ import annotations
 
+import awkward as ak
+import numpy as np
 import pytest
 
 import ragged
@@ -332,4 +334,60 @@ def test_var():
         ragged.var(data, axis=(0, 1, 2)).tolist()
         == ragged.var(data, axis=(-1, 0, 1)).tolist()
         == pytest.approx(9.9825)
+    )
+
+
+def test_sum_dtype_argument():
+    data = ragged.array([[1, 2, 3], [4, 5]])
+    assert data.dtype == np.dtype(np.int64)
+
+    result = ragged.sum(data, dtype=np.dtype(np.float32))
+    assert result.dtype == np.dtype(np.float32)
+    assert result.tolist() == pytest.approx(15.0)
+
+
+def test_prod_dtype_argument():
+    data = ragged.array([[1, 2, 3], [4, 5]])
+    assert data.dtype == np.dtype(np.int64)
+
+    result = ragged.prod(data, dtype=np.dtype(np.float32))
+    assert result.dtype == np.dtype(np.float32)
+    assert result.tolist() == pytest.approx(120.0)
+
+
+def test_mean_integer_not_truncated():
+    result = ragged.mean(ragged.array([1, 2]))
+    assert result.dtype.kind == "f"
+    assert result.tolist() == pytest.approx(1.5)
+
+
+def test_var_integer_not_truncated():
+    result = ragged.var(ragged.array([1, 2, 4]))
+    assert result.dtype.kind == "f"
+    assert result.tolist() == pytest.approx(1.5555556)
+
+
+def test_std_integer_not_truncated():
+    result = ragged.std(ragged.array([1, 2, 4]))
+    assert result.dtype.kind == "f"
+    assert result.tolist() == pytest.approx(1.2472191)
+
+
+def test_mean_var_std_float32_preserved():
+    data = ragged.array(np.array([1.0, 2.0, 4.0], dtype=np.float32))
+    assert ragged.mean(data).dtype == np.dtype(np.float32)
+    assert ragged.var(data).dtype == np.dtype(np.float32)
+    assert ragged.std(data).dtype == np.dtype(np.float32)
+
+
+def test_tuple_axis_out_of_bounds():
+    data = ragged.array([[[0, 1, 2], []], [], [[3, 4], [5], [6, 7, 8, 9]]])
+    with pytest.raises(ak.errors.AxisError):
+        ragged.sum(data, axis=(0, 5))
+
+
+def test_tuple_axis_includes_zero():
+    data = ragged.array([[[0, 1, 2], []], [], [[3, 4], [5], [6, 7, 8, 9]]])
+    assert (
+        ragged.sum(data, axis=(0, 1)).tolist() == ragged.sum(data, axis=(1, 0)).tolist()
     )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes three confirmed bugs in `src/ragged/_spec_statistical_functions.py`.

## 1. `sum` / `prod` ignored their `dtype` argument

The cast condition was inverted: it cast only when the dtypes already
matched (a no-op) and skipped the cast when they actually differed.

- **Before:** `ragged.sum(ragged.array([[1, 2, 3], [4, 5]]), dtype=np.float32)` returned `int64`.
- **After:** returns `float32` (value `15.0`). The cast now happens via the
  existing `_ensure_dtype` helper, which also handles the 0-d scalar case.

## 2. `mean` / `var` / `std` truncated integer input

These functions cast their floating-point result back to `x.dtype`,
truncating integer input.

- **Before:** `ragged.mean(ragged.array([1, 2]))` returned `1`;
  `ragged.var(ragged.array([1, 2, 4]))` returned `1` (true ≈ 1.556).
- **After:** integer/bool input keeps its natural floating-point dtype
  (`mean([1, 2]) == 1.5`), matching the Array API requirement that these
  functions return a floating-point data type. Floating input (e.g.
  `float32`) is still cast back to preserve the "same data type as `x`"
  promise. Docstrings' "Returns" wording updated accordingly. `std`
  delegates to `var`, so it follows automatically.

## 3. `_regularize_axis` built an error message but never raised it

For tuple axes, the out-of-bounds branch assigned `msg` but never raised,
and the bound check `0 < out[-1]` incorrectly rejected axis `0`.

- **Before:** `ragged.sum(x, axis=(0, 5))` fell through to a less helpful
  awkward error.
- **After:** raises `ak.errors.AxisError` with a clear message; the bound
  is now `0 <= out[-1] < ndim`, so tuple axes including `0` work.

## Tests

Added regression tests in `tests/test_spec_statistical_functions.py`
covering all three fixes. Full suite passes (`1305 passed, 6 skipped`),
`mypy --strict` and all pre-commit hooks clean.

Part of #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
