### PR TITLE
fix: dtype handling in elementwise functions

### DIFF
--- a/src/ragged/_helper_functions.py
+++ b/src/ragged/_helper_functions.py
@@ -9,10 +9,12 @@ from awkward.contents import Content, ListArray, ListOffsetArray
 
 from ._spec_array_object import array
 
+_NUMPY_GE_2_1 = np.lib.NumpyVersion(np.__version__) >= "2.1.0"
+
 
 def regularise_to_float(t: np.dtype, /) -> np.dtype:
     # Ensure compatibility with numpy 2.0.0
-    if np.__version__ >= "2.1":
+    if _NUMPY_GE_2_1:
         # Just pass and return the input type if the numpy version is not 2.0.0
         return t
 

--- a/src/ragged/_spec_elementwise_functions.py
+++ b/src/ragged/_spec_elementwise_functions.py
@@ -669,13 +669,15 @@ def imag(x: array, /) -> array:
     """
 
     (a,) = _unbox(x)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        return _box(
-            type(x),
-            (a - np.conjugate(a)) / 2j,
-            dtype=np.dtype(f"f{x.dtype.itemsize // 2}"),
-        )
+    if x.dtype.kind == "c":
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return _box(
+                type(x),
+                (a - np.conjugate(a)) / 2j,
+                dtype=np.dtype(f"f{x.dtype.itemsize // 2}"),
+            )
+    return _box(type(x), np.zeros_like(a), dtype=x.dtype)
 
 
 def isfinite(x: array, /) -> array:
@@ -1061,13 +1063,15 @@ def real(x: array, /) -> array:
     """
 
     (a,) = _unbox(x)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        return _box(
-            type(x),
-            (a + np.conjugate(a)) / 2,
-            dtype=np.dtype(f"f{x.dtype.itemsize // 2}"),
-        )
+    if x.dtype.kind == "c":
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return _box(
+                type(x),
+                (a + np.conjugate(a)) / 2,
+                dtype=np.dtype(f"f{x.dtype.itemsize // 2}"),
+            )
+    return _box(type(x), a, dtype=x.dtype)
 
 
 def remainder(x1: array, x2: array, /) -> array:
@@ -1116,6 +1120,8 @@ def round(x: array, /) -> array:  # pylint: disable=W0622
     """
 
     (a,) = _unbox(x)
+    if x.dtype.kind in "biu":
+        return _box(type(x), a, dtype=x.dtype)
     if x.dtype in (np.complex64, np.complex128):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -1132,6 +1138,7 @@ def round(x: array, /) -> array:  # pylint: disable=W0622
             type(x),
             whole
             + ((abs_frac == 0.5) * (whole % 2 != 0) + (abs_frac > 0.5)) * np.sign(frac),
+            dtype=x.dtype,
         )
 
 
@@ -1326,4 +1333,4 @@ def trunc(x: array, /) -> array:
     https://data-apis.org/array-api/latest/API_specification/generated/array_api.trunc.html
     """
 
-    return _box(type(x), np.trunc(*_unbox(x)))
+    return _box(type(x), np.trunc(*_unbox(x)), dtype=regularise_to_float(x.dtype))

--- a/tests/test_spec_elementwise_functions.py
+++ b/tests/test_spec_elementwise_functions.py
@@ -1048,3 +1048,76 @@ def test_trunc(device, x):
     assert result.shape == x.shape
     assert xp.trunc(first(x)) == first(result)
     assert xp.trunc(first(x)).dtype == result.dtype
+
+
+# Regression tests for dtype bugs
+
+
+@pytest.mark.parametrize("device", devices)
+def test_real_float64_keeps_dtype(device):
+    """real() of a real float64 array must return float64, not float32."""
+    x = ragged.array(np.array([1.0, 2.0, 3.0], dtype=np.float64))
+    result = ragged.real(x.to_device(device))
+    assert result.dtype == np.float64
+
+
+@pytest.mark.parametrize("device", devices)
+def test_imag_float64_keeps_dtype(device):
+    """imag() of a real float64 array must return float64 zeros, not float32."""
+    x = ragged.array(np.array([1.0, 2.0, 3.0], dtype=np.float64))
+    result = ragged.imag(x.to_device(device))
+    assert result.dtype == np.float64
+    assert float(first(result)) == 0.0
+
+
+@pytest.mark.parametrize("device", devices)
+def test_imag_real_zeros_for_real_input(device):
+    """imag() of a real array must return all zeros."""
+    x = ragged.array(np.array([1.5, -2.5, 3.5], dtype=np.float32))
+    result = ragged.imag(x.to_device(device))
+    assert result.dtype == np.float32
+    assert float(first(result)) == 0.0
+
+
+@pytest.mark.skipif(
+    not has_complex_dtype,
+    reason=f"complex not allowed in np.array_api version {np.__version__}",
+)
+@pytest.mark.parametrize("device", devices)
+def test_real_complex64_maps_to_float32(device):
+    """real() of complex64 must return float32."""
+    x = ragged.array(np.array([1.0 + 2.0j, 3.0 + 4.0j], dtype=np.complex64))
+    result = ragged.real(x.to_device(device))
+    assert result.dtype == np.float32
+
+
+@pytest.mark.skipif(
+    not has_complex_dtype,
+    reason=f"complex not allowed in np.array_api version {np.__version__}",
+)
+@pytest.mark.parametrize("device", devices)
+def test_imag_complex128_maps_to_float64(device):
+    """imag() of complex128 must return float64."""
+    x = ragged.array(np.array([1.0 + 2.0j, 3.0 + 4.0j], dtype=np.complex128))
+    result = ragged.imag(x.to_device(device))
+    assert result.dtype == np.float64
+
+
+@pytest.mark.parametrize("device", devices)
+def test_round_int64_keeps_dtype(device):
+    """round() of an int64 array must return int64, not float64."""
+    x = ragged.array(np.array([1, 2, 3], dtype=np.int64))
+    result = ragged.round(x.to_device(device))
+    assert result.dtype == np.int64
+    assert int(first(result)) == 1
+
+
+@pytest.mark.parametrize("device", devices)
+def test_trunc_int_matches_ceil_floor_dtype(device):
+    """trunc() of an int array should behave consistently with ceil/floor."""
+    x_int_arr = ragged.array(np.array([1, 2, 3], dtype=np.int64))
+    result_trunc = ragged.trunc(x_int_arr.to_device(device))
+    result_ceil = ragged.ceil(x_int_arr.to_device(device))
+    result_floor = ragged.floor(x_int_arr.to_device(device))
+    assert result_trunc.dtype == result_ceil.dtype
+    assert result_trunc.dtype == result_floor.dtype


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

This PR fixes four confirmed dtype bugs in the elementwise functions module and one string-comparison bug in the helper module.

### Fix 1 — `real` and `imag` downcast real-valued input

**Before:** `ragged.real(float64_array)` returned `float32`; `ragged.imag(float64_array)` returned `float32` zeros. The computation `np.dtype(f"f{x.dtype.itemsize // 2}")` (intended for complex → real mapping) was applied unconditionally, halving the precision of real inputs.

**After:** When `x.dtype.kind != "c"`, `real(x)` returns a boxed copy of the underlying data with `x.dtype` unchanged, and `imag(x)` returns `np.zeros_like(a)` with `dtype=x.dtype`. Complex input still correctly maps `complex64 → float32` and `complex128 → float64`.

### Fix 2 — `round` on integer input returns float64

**Before:** `ragged.round(int64_array)` returned `float64` because `np.modf` promotes integers to float.

**After:** For `x.dtype.kind in "biu"` (bool, unsigned int, signed int), `round` returns a boxed identity — same values, same dtype — before reaching the `modf` branch. The float branch now also explicitly passes `dtype=x.dtype` to `_box` to prevent silent promotion.

### Fix 3 — `trunc` inconsistency with `ceil`/`floor`

**Before:** `trunc` called `_box(type(x), np.trunc(*_unbox(x)))` without a `dtype` argument, while `ceil` and `floor` both pass `dtype=regularise_to_float(x.dtype)` for NumPy <2.1 compatibility.

**After:** `trunc` now passes `dtype=regularise_to_float(x.dtype)` to match `ceil` and `floor`.

### Fix 4 — String version comparison in `_helper_functions.py`

**Before:** `if np.__version__ >= "2.1":` — lexicographic comparison that would misorder versions like `"2.10"` vs `"2.9"`.

**After:** `_NUMPY_GE_2_1 = np.lib.NumpyVersion(np.__version__) >= "2.1.0"` — computed once at module level using NumPy's own version-comparison utility.

## Test plan

- [x] Regression tests added for `real`/`imag` of float64 input preserving dtype
- [x] Regression tests added for `imag` of real input returning zeros with correct dtype
- [x] Regression tests added for `real`/`imag` of complex64/complex128 still mapping to float32/float64
- [x] Regression test added for `round` of int64 input returning int64
- [x] Regression test added for `trunc` dtype matching `ceil`/`floor`
- [x] Full test suite: 1304 passed, 6 skipped (pre-existing skips for numpy array_api)
- [x] `prek -a --quiet` passes (ruff + mypy --strict)

Part of #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
