### PR TITLE
fix: take with negative axis; remove dead code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ required-imports = ["from __future__ import annotations"]
 
 
 [tool.pylint]
-py-version = "3.9"
+py-version = "3.10"
 ignore-paths = [".*/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/src/ragged/_helper_functions.py
+++ b/src/ragged/_helper_functions.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import awkward as ak
 import numpy as np
-from awkward.contents import Content, ListArray, ListOffsetArray
 
 from ._spec_array_object import array
 
@@ -24,29 +23,6 @@ def regularise_to_float(t: np.dtype, /) -> np.dtype:
         return np.float64
     else:
         return t
-
-
-def is_sorted_descending_all_levels(x: array, /) -> bool:
-    """
-    Checks whether all nested lists in the array are sorted by descending length
-    at every level of the array (ignoring leaves).
-
-    Returns:
-        bool: True if all nested lists are sorted descending by length, False otherwise.
-    """
-    array_ak = ak.Array(x._impl)  # pylint: disable=protected-access
-    layout: Content = ak.to_layout(array_ak)
-
-    def check(node: Content) -> bool:
-        if isinstance(node, ListOffsetArray | ListArray):
-            lengths: ak.Array = ak.num(node, axis=1)
-            if not ak.all(lengths[:-1] >= lengths[1:]):  # pylint: disable=E1136
-                return False
-            return check(node.content)
-        else:
-            return True
-
-    return check(layout)
 
 
 def is_effectively_regular(x: array) -> bool:
@@ -81,7 +57,6 @@ def is_effectively_regular(x: array) -> bool:
 
 def is_regular_or_effectively_regular(x: Any) -> bool:
     try:
-        layout = x.layout
         layout = x._impl.layout  # pylint: disable=W0212
         if isinstance(layout, ak.contents.RegularArray) and (
             isinstance(layout.content, ak.contents.NumpyArray)

--- a/src/ragged/_spec_array_object.py
+++ b/src/ragged/_spec_array_object.py
@@ -1406,32 +1406,6 @@ class array:  # pylint: disable=C0103
         return self._ensure_array(other).__matmul__(self)
 
 
-def _is_shared(
-    x1: array | ak.Array | SupportsDLPack, x2: array | ak.Array | SupportsDLPack
-) -> bool:
-    x1_buf = x1._impl if isinstance(x1, array) else x1  # pylint: disable=W0212
-    x2_buf = x2._impl if isinstance(x2, array) else x2  # pylint: disable=W0212
-
-    if isinstance(x1_buf, ak.Array):
-        x1_buf = x1_buf.layout
-        while not isinstance(x1_buf, NumpyArray):
-            x1_buf = x1_buf.content
-        x1_buf = x1_buf.data
-
-    if isinstance(x2_buf, ak.Array):
-        x2_buf = x2_buf.layout
-        while not isinstance(x2_buf, NumpyArray):
-            x2_buf = x2_buf.content
-        x2_buf = x2_buf.data
-
-    while x1_buf.base is not None:  # type: ignore[union-attr]
-        x1_buf = x1_buf.base  # type: ignore[union-attr]
-    while x2_buf.base is not None:  # type: ignore[union-attr]
-        x2_buf = x2_buf.base  # type: ignore[union-attr]
-
-    return x1_buf is x2_buf
-
-
 def _unbox(*inputs: array) -> tuple[ak.Array | SupportsDLPack, ...]:
     if len(inputs) > 1 and any(type(inputs[0]) is not type(x) for x in inputs):
         types = "\n".join(f"{type(x).__module__}.{type(x).__name__}" for x in inputs)

--- a/src/ragged/_spec_indexing_functions.py
+++ b/src/ragged/_spec_indexing_functions.py
@@ -49,7 +49,7 @@ def take(x: array, indices: array, /, *, axis: None | int = None) -> array:
 
     original_axis = axis
     if axis < 0:
-        axis += x.ndim + 1
+        axis += x.ndim
     if not 0 <= axis < x.ndim:
         msg = f"axis {original_axis} is out of bounds for array of dimension {x.ndim}"
         raise ak.errors.AxisError(msg)

--- a/src/ragged/_spec_manipulation_functions.py
+++ b/src/ragged/_spec_manipulation_functions.py
@@ -454,9 +454,6 @@ def reshape(x: array, /, shape: tuple[int, ...], *, copy: None | bool = None) ->
     if neg_one_count > 1:
         msg = "reshape: only one dimension may be -1"
         raise ValueError(msg)
-    if any(s < -1 or s == 0 and s != 0 for s in shape):
-        # zero-size dims are allowed; negative dims other than -1 are not
-        pass
     if any(s < -1 for s in shape):
         msg = "reshape: shape dimensions must be -1 or non-negative"
         raise ValueError(msg)

--- a/tests/test_spec_indexing_functions.py
+++ b/tests/test_spec_indexing_functions.py
@@ -6,8 +6,68 @@ https://data-apis.org/array-api/latest/API_specification/indexing_functions.html
 
 from __future__ import annotations
 
+import numpy as np
+import pytest
+
 import ragged
 
 
 def test_existence():
     assert ragged.take is not None
+
+
+def test_take_1d():
+    x = ragged.array([10, 20, 30, 40, 50])
+    indices = ragged.array([0, 2, 4])
+    result = ragged.take(x, indices)
+    assert result.tolist() == [10, 30, 50]
+
+
+def test_take_2d_axis0():
+    x = ragged.array(np.arange(12).reshape(3, 4))
+    indices = ragged.array([0, 2])
+    result = ragged.take(x, indices, axis=0)
+    assert result.tolist() == ragged.take(x, indices, axis=-2).tolist()
+    assert result.tolist() == [[0, 1, 2, 3], [8, 9, 10, 11]]
+
+
+def test_take_2d_axis1():
+    x = ragged.array(np.arange(12).reshape(3, 4))
+    indices = ragged.array([1, 3])
+    result = ragged.take(x, indices, axis=1)
+    assert result.tolist() == ragged.take(x, indices, axis=-1).tolist()
+    assert result.tolist() == [[1, 3], [5, 7], [9, 11]]
+
+
+def test_take_negative_axis_matches_positive():
+    """Regression test: negative axis must wrap correctly (axis += ndim, not ndim+1)."""
+    x = ragged.array(np.arange(6).reshape(2, 3))
+
+    # axis=-2 must equal axis=0 on a 2-D array
+    row_indices = ragged.array([0, 1])
+    result_pos0 = ragged.take(x, row_indices, axis=0)
+    result_neg2 = ragged.take(x, row_indices, axis=-2)
+    assert result_pos0.tolist() == result_neg2.tolist()
+
+    # axis=-1 must equal axis=1 on a 2-D array
+    col_indices = ragged.array([0, 2])
+    result_pos1 = ragged.take(x, col_indices, axis=1)
+    result_neg1 = ragged.take(x, col_indices, axis=-1)
+    assert result_pos1.tolist() == result_neg1.tolist()
+
+
+def test_take_out_of_range_negative_axis():
+    """Out-of-range negative axis must still raise AxisError."""
+    import awkward as ak
+
+    x = ragged.array(np.arange(6).reshape(2, 3))
+    indices = ragged.array([0])
+    with pytest.raises(ak.errors.AxisError, match="out of bounds"):
+        ragged.take(x, indices, axis=-3)
+
+
+def test_take_requires_axis_for_nd():
+    x = ragged.array(np.arange(6).reshape(2, 3))
+    indices = ragged.array([0])
+    with pytest.raises(TypeError, match="axis"):
+        ragged.take(x, indices)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Part of #144

- **`take` negative-axis bug** (`_spec_indexing_functions.py`): `axis += x.ndim + 1` was copied from `expand_dims` whose valid range is `[-N-1, N]`, but `take`'s valid range is `[-N, N)`. Changed to `axis += x.ndim`. Before the fix, `ragged.take(x2d, indices, axis=-1)` raised `AxisError`; now it correctly selects the last axis.

- **Dead fast path in `is_regular_or_effectively_regular`** (`_helper_functions.py`): the line `layout = x.layout` always raised `AttributeError` (swallowed by the surrounding `except`) because `ragged.array` has no `.layout` attribute, preventing the faster layout-based check from ever running. Deleted that line so `layout = x._impl.layout` is reached and the fast path works.

- **Removed `is_sorted_descending_all_levels`** (`_helper_functions.py`): never referenced anywhere in `src/` or `tests/`. Removed the function and its now-orphaned imports (`Content`, `ListArray`, `ListOffsetArray`).

- **Removed `_is_shared`** (`_spec_array_object.py`): never called anywhere in `src/` or `tests/`.

- **Removed dead no-op validation block in `reshape`** (`_spec_manipulation_functions.py`): the `if any(s < -1 or s == 0 and s != 0 for s in shape): pass` block (condition is a tautology that always falls through to `pass`) was a dead code leftover. The real validation `if any(s < -1 for s in shape)` immediately follows it.

- **Fix `[tool.pylint] py-version`** (`pyproject.toml`): was `"3.9"`, contradicting `requires-python = ">=3.10"`. Changed to `"3.10"`.

## Test plan

- [ ] `uv run --extra test pytest -q` — 1303 passed, 6 skipped (all pre-existing skips)
- [ ] `prek -a --quiet` — all hooks pass
- [ ] New regression tests in `tests/test_spec_indexing_functions.py`:
  - `axis=-1` on 2-D equals `axis=1`
  - `axis=-2` on 2-D equals `axis=0`
  - Out-of-range `axis=-3` on 2-D raises `AxisError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)