### PR TITLE
fix: device argument was relabeling without moving data

### DIFF
--- a/src/ragged/_spec_array_object.py
+++ b/src/ragged/_spec_array_object.py
@@ -236,6 +236,8 @@ class array:  # pylint: disable=C0103
             elif isinstance(self._impl, np.ndarray) and device == "cuda":
                 cp = _import.cupy()
                 self._impl = cp.array(self._impl)
+            elif not isinstance(self._impl, ak.Array | np.ndarray) and device == "cpu":
+                self._impl = np.asarray(self._impl.get())
             self._device = device
         else:
             if isinstance(self._impl, ak.Array):
@@ -1462,7 +1464,7 @@ def _box(
         if device is None:
             device = device_observed
         elif device != device_observed:
-            output = ak.to_backend(output, device)
+            impl = ak.to_backend(impl, device)
 
     elif isinstance(output, np.number):
         impl = np.array(output)
@@ -1477,7 +1479,7 @@ def _box(
             device = device_observed
         elif device != device_observed:
             cp = _import.cupy()
-            output = cp.array(output)
+            impl = cp.array(impl)
 
     else:
         impl = output
@@ -1492,10 +1494,10 @@ def _box(
             device = device_observed
         elif device != device_observed:
             if device == "cpu":
-                output = np.array(output)
+                impl = np.asarray(impl.get())
             else:
                 cp = _import.cupy()
-                output = cp.array(output)
+                impl = cp.array(impl)
 
         if shape != ():
             impl = ak.Array(impl)

--- a/tests/test_spec_array_object.py
+++ b/tests/test_spec_array_object.py
@@ -260,3 +260,73 @@ def test_T_consistency_with_mT():
     """Verify .T and .mT return identical results for 2D."""
     arr = ragged.array([[5, 4, 3], [2, 1, 0]])
     assert ak.to_list(arr.T._impl) == ak.to_list(arr.mT._impl)
+
+
+# ---------------------------------------------------------------------------
+# Device-handling regression tests (fix: _box and __init__ actually move data)
+# ---------------------------------------------------------------------------
+
+
+def test_box_cpu_noop_nd():
+    """_box with device="cpu" on a CPU-backed ak.Array is a no-op and stays CPU."""
+    from ragged._spec_array_object import _box
+
+    x = ragged.array([[1.0, 2.0], [3.0]])
+    result = _box(type(x), x._impl, device="cpu")
+    assert result.device == "cpu"
+    assert isinstance(result._impl, ak.Array)
+    assert ak.backend(result._impl) == "cpu"
+
+
+def test_box_cpu_noop_0d():
+    """_box with device="cpu" on a CPU 0-d numpy array is a no-op and stays CPU."""
+    from ragged._spec_array_object import _box
+
+    x = ragged.array(np.float64(3.14))
+    result = _box(type(x), x._impl, device="cpu")
+    assert result.device == "cpu"
+    assert isinstance(result._impl, np.ndarray)
+
+
+def test_box_cuda_raises_or_moves():
+    """_box with device="cuda" on a CPU array either raises (no CuPy) or moves data."""
+    from ragged._spec_array_object import _box
+
+    x = ragged.array([[1.0, 2.0], [3.0]])
+    if cp is None:
+        # No CuPy: must raise with ModuleNotFoundError, not silently return a
+        # mislabeled array (which is what the pre-fix code did).
+        with pytest.raises(ModuleNotFoundError):
+            _box(type(x), x._impl, device="cuda")
+    else:
+        result = _box(type(x), x._impl, device="cuda")
+        assert result.device == "cuda"
+        assert ak.backend(result._impl) == "cuda"
+
+
+def test_ones_like_explicit_cpu_device_nd():
+    """ones_like with device="cpu" on a CPU array returns a properly CPU-backed array."""
+    x = ragged.array([[1.0, 2.0], [3.0]])
+    result = ragged.ones_like(x, device="cpu")
+    assert result.device == "cpu"
+    assert isinstance(result._impl, ak.Array)
+    assert ak.backend(result._impl) == "cpu"
+    assert result.tolist() == [[1.0, 1.0], [1.0]]
+
+
+def test_ones_like_explicit_cpu_device_0d():
+    """ones_like with device="cpu" on a CPU 0-d array returns a properly CPU-backed array."""
+    x = ragged.array(np.float64(1.0))
+    result = ragged.ones_like(x, device="cpu")
+    assert result.device == "cpu"
+    assert isinstance(result._impl, np.ndarray)
+
+
+def test_init_cupy_to_cpu_conversion():
+    """array.__init__ with device="cpu" on a CuPy scalar moves data to NumPy."""
+    if cp is None:
+        pytest.skip("CuPy not available")
+    cupy_scalar = cp.float64(2.0)
+    a = ragged.array(cupy_scalar, device="cpu")
+    assert a.device == "cpu"
+    assert isinstance(a._impl, np.ndarray)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two confirmed bugs in device handling where data was labelled as being on a
device without actually being moved there.

### Fix 1: `_box` was assigning to `output` instead of `impl`

In `_box` (`src/ragged/_spec_array_object.py`), all three branches that
perform a device conversion assigned the moved result to `output` — but
`output` is never read again after that point. `cls._new` receives `impl`,
which was left pointing to the original (unmoved) data. The fix is to assign
to `impl` in all three branches:

- `ak.Array` branch: `output = ak.to_backend(output, device)` → `impl = ak.to_backend(impl, device)`
- `np.number` branch: `output = cp.array(output)` → `impl = cp.array(impl)`
- generic ndarray/scalar branch: `output = np.array(output)` / `output = cp.array(output)` → assign to `impl`

Additionally, the CuPy→CPU path in the generic branch used `np.array(impl)`
which does not copy from device memory in modern CuPy. Changed to
`np.asarray(impl.get())` to match the pattern already used in `to_device`
(line ~1173).

**Confirmed bug on `main`:** `_box(type(x), x._impl, device="cuda")` returned a
NumPy-backed array whose `.device` reported `"cuda"`. This affected
`empty_like`/`full_like`/`ones_like`/`zeros_like` when called with an explicit
`device=` argument that differed from the input's device.

### Fix 2: `array.__init__` missing CuPy→CPU branch for 0-d scalars

In `__init__`, the device-conversion block handled `ak.Array` backend moves and
`np.ndarray`→CuPy (`device == "cuda"`), but if `self._impl` was a CuPy 0-d
array and `device == "cpu"` was requested, no conversion happened — yet
`self._device = "cpu"` was set. Added the missing `elif` branch that calls
`.get()` (same pattern as `to_device`).

## Tests added

New tests in `tests/test_spec_array_object.py`:

- `test_box_cpu_noop_nd` / `test_box_cpu_noop_0d`: verify that `_box` with
  `device="cpu"` on a CPU-backed input is a no-op and the result really is
  NumPy/CPU-backed.
- `test_box_cuda_raises_or_moves`: without CuPy, requesting `device="cuda"`
  now raises `ModuleNotFoundError` (before the fix it silently returned a
  mislabelled array); with CuPy present, asserts the backend is actually
  "cuda".
- `test_ones_like_explicit_cpu_device_nd` / `test_ones_like_explicit_cpu_device_0d`:
  end-to-end smoke tests for the `ones_like(x, device="cpu")` path.
- `test_init_cupy_to_cpu_conversion`: skipped without CuPy; verifies the new
  `__init__` branch.

## CUDA paths not exercised locally

**This machine has no GPU or CuPy installation.** The fixes to the CUDA
transfer paths (`ak.to_backend(..., "cuda")`, `cp.array(impl)`,
`impl.get()`) follow the exact patterns already used elsewhere in the same
file (`to_device`, `from_dlpack`, etc.) and are structurally correct, but
they must be verified on a CUDA machine before merging.

Part of #144

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
